### PR TITLE
Container uses Application Context in sample code

### DIFF
--- a/cloud-db/basics/android.md
+++ b/cloud-db/basics/android.md
@@ -28,7 +28,7 @@ In the SDK, you can get the public or private database using:
 
 ```java
 // get Skygear Container
-Container skygear = Container.defaultContainer(this);
+Container skygear = Container.defaultContainer(getApplicationContext());
 
 // get public database
 Database publicDatabase = skygear.getPublicDatabase();


### PR DESCRIPTION
According to the [API](https://docs.skygear.io/android/reference/io/skygear/skygear/Container.html#defaultContainer-android.content.Context-) spec, `Container.defaultContainer(context)` should pass an Application Context.