### PR TITLE
update JS cloud function code sample of database connection

### DIFF
--- a/cloud-function/calling-skygear-api/js.md
+++ b/cloud-function/calling-skygear-api/js.md
@@ -114,28 +114,27 @@ container.publicDB.delete({
 
 In the [database hooks][doc-cloud-code-db-hooks], you receive the `pool` argument
 which is an instance of the [SQLAlchemy engine connection].
-In other types of cloud code functions,
-you can obtain such an instance by calling:
+In other types of cloud code functions, you can obtain such an instance by calling `pool`.
+In this below example, we have connected to the Skygear database and made a raw SQL query in a lambda function.
 
 ```javaScript
 const skygearCloud = require('skygear/cloud');
-const skygear = require('skygear');
 
-const container = new skygearCloud.CloudCodeContainer();
-container.apiKey = '<your-app-api-key>';
-container.endPoint = '<your-app-endpoint';
-
-skygearCloud.poolConnect(function (err,client,done) {
-  client.query(`SELECT * FROM app_sample.sampleTable WHERE x IN y`, function(err, res){
-    done();
-    if (err) {
-      console.log(err);
-      return;
-    }
-    console.log(res);
-  })
-  return;
-})
+skygearCloud.op('queryX', () =>
+  skygearCloud.pool
+    .query(
+      `SELECT * FROM app_sample.sampleTable WHERE x='y'`
+    )
+    .then(res => {
+      return {
+        results: res.rows
+      };
+    })
+    .catch(err => {
+      console.error(err.stack);
+      return null;
+    })
+);
 ```
 Note: you should fill in `app_sample.sampleTable` as `app_<your-app-name>.<table-name>`.
 

--- a/cloud-function/calling-skygear-api/js.md
+++ b/cloud-function/calling-skygear-api/js.md
@@ -112,14 +112,32 @@ container.publicDB.delete({
 
 ## Database Queries
 
-In the [database hooks][doc-cloud-code-db-hooks], you receive the `db` argument
+In the [database hooks][doc-cloud-code-db-hooks], you receive the `pool` argument
 which is an instance of the [SQLAlchemy engine connection].
-In other types of cloud code functions, 
-you can obtain such an instance by importing `db` and call
-`db.conn()` from the `skygear.utils` module.
+In other types of cloud code functions,
+you can obtain such an instance by calling:
 
-(TODO)
+```javaScript
+const skygearCloud = require('skygear/cloud');
+const skygear = require('skygear');
 
+const container = new skygearCloud.CloudCodeContainer();
+container.apiKey = '<your-app-api-key>';
+container.endPoint = '<your-app-endpoint';
+
+skygearCloud.poolConnect(function (err,client,done) {
+  client.query(`SELECT * FROM app_sample.sampleTable WHERE x IN y`, function(err, res){
+    done();
+    if (err) {
+      console.log(err);
+      return;
+    }
+    console.log(res);
+  })
+  return;
+})
+```
+Note: you should fill in `app_sample.sampleTable` as `app_<your-app-name>.<table-name>`.
 
 ## PubSub Events
 

--- a/cloud-function/calling-skygear-api/js.md
+++ b/cloud-function/calling-skygear-api/js.md
@@ -129,11 +129,11 @@ skygearCloud.op('queryX', () =>
       return {
         results: res.rows
       };
-    })
+    });
     .catch(err => {
       console.error(err.stack);
       return null;
-    })
+    });
 );
 ```
 Note: you should fill in `app_sample.sampleTable` as `app_<your-app-name>.<table-name>`.


### PR DESCRIPTION
Have been faked a few times by the documentation. The original `db.conn()` function is actually for the Python cloud functions not for the JavaScript cloud functions. However, I am not sure if my sample codes are up to standard. Let me know if there's anything you want me to update. 