### PR TITLE
Update cloud push example #6

### DIFF
--- a/cloud-function/calling-skygear-api/js.md
+++ b/cloud-function/calling-skygear-api/js.md
@@ -34,7 +34,7 @@ const TaskRecord = skygear.Record.extend('task');
 const query = new skygear.Query(TaskRecord);
 query.equalTo('_id', 'cdfc7bb4-afd3-464c-a430-c9564c2202cf');
 container.publicDB.query(query).then((records) => {
-	console.log(records);
+  console.log(records);
 });
 ```
 
@@ -89,9 +89,9 @@ const container = skygearCloud.getContainer('admin');
 // the action will be done on behalf of the given user
 const Task = skygear.Record.extend('task');
 const TaskRecord = new Task({
-	description: 'Complete the sales report'});
+  description: 'Complete the sales report'});
 container.publicDB.save(TaskRecord).then((result) => {
-	console.log(result);
+  console.log(result);
 });
 ```
 
@@ -101,11 +101,11 @@ Deleting a record can be done in a similar fashion:
 const container = skygearCloud.getContainer('admin');
 
 container.publicDB.delete({
-	id: 'note/cdfc7bb4-afd3-464c-a430-c9564c2202cf'
+  id: 'note/cdfc7bb4-afd3-464c-a430-c9564c2202cf'
 }).then((record) => {
-	console.log(record);
+  console.log(record);
 }, (error) => {
-	console.error(error);
+  console.error(error);
 });
 ```
 

--- a/cloud-function/calling-skygear-api/js.md
+++ b/cloud-function/calling-skygear-api/js.md
@@ -195,12 +195,12 @@ container.push.sendToUser(
 sendToUser(users, notification, topic)
 ```
 
-- **users** (string or array of string)
+- **`users`** (string or array of string)
 
   An array of User IDs. If you are sending a notification to a single
   user, you can also specify the User ID in string instead of array.
 
-- **notification** (dictionary)
+- **`notification`** (dictionary)
 
   It should be a Python dictionary with two keys, `apns` and `gcm`,
   representing the argument for
@@ -208,7 +208,7 @@ sendToUser(users, notification, topic)
   and [Google Cloud Messaging][gcm]
   respectively.
 
-- **topic** (string)
+- **`topic`** (string)
 
   The device topic, refer to application bundle
   identifier on iOS and application package name on Android
@@ -218,12 +218,12 @@ sendToUser(users, notification, topic)
 sendToDevice(devices, notification, topic)
 ```
 
-- **devices** (string or array of string)
+- **`devices`** (string or array of string)
 
   An array of Device IDs. If you are sending a notification to a single
   device, you can also specify the Device ID in string instead of array.
 
-- **notification** (dictionary)
+- **`notification`** (dictionary)
 
   It should be a Python dictionary with two keys, `apns` and `gcm`,
   representing the argument for
@@ -231,7 +231,7 @@ sendToDevice(devices, notification, topic)
   and [Google Cloud Messaging][gcm]
   respectively.
 
-- **topic** (string)
+- **`topic`** (string)
 
   The device topic, refer to application bundle
   identifier on iOS and application package name on Android

--- a/cloud-function/calling-skygear-api/js.md
+++ b/cloud-function/calling-skygear-api/js.md
@@ -215,7 +215,7 @@ sendToUser(users, notification, topic)
 
 
 ```javascript
-sendToDevice(users, notification, topic)
+sendToDevice(devices, notification, topic)
 ```
 
 - **devices** (string or array of string)

--- a/cloud-function/calling-skygear-api/python.md
+++ b/cloud-function/calling-skygear-api/python.md
@@ -197,7 +197,9 @@ The `publish` function has no return values and takes two arguments:
 ## Push Notifications
 
 You can send push notifications to users from the cloud code
-using the `push_user` function in the `skygear.action` module.
+using the `push_user`, `push_users`, `push_device` and `push_devices` function in the `skygear.action` module.
+
+Below example shows how you can push to a user using `push_user`
 
 ```python
 from skygear.container import SkygearContainer
@@ -229,8 +231,10 @@ response = push_user(container, user_id, notification)
 
 ## Parameters
 
+### Push to one user
+
 ```python
-push_user(container, user_id, notification)
+push_user(container, user_id, notification, topic=None)
 ```
 
 - **container** (`SkygearContainer`)
@@ -250,16 +254,98 @@ push_user(container, user_id, notification)
   and [Google Cloud Messaging][gcm]
   respectively.
 
-If you need to send push notifications to multiple users,
-you can pass a list of user IDs (Python list) to the `push_users` function
-(don't miss the ending "s" of `push_users`!).
-The other arguments remain the same.
+- **topic** (string)
+
+  [Optional] The device topic, refer to application bundle identifier on iOS and application package name on Android
+
+### Push to users
+
+```python
+push_users(container, user_ids, notification, topic=None)
+```
+
+- **container** (`SkygearContainer`)
+
+  An instance of the `SkygearContainer`, with the API key configured.
+
+- **user_ids** (List)
+
+  A list of Skygear user ID who will receive the push notification. The prefix
+  `user/` is not necessary for the user ID.
+
+- **notification** (dictionary)
+
+  It should be a Python dictionary with two keys, `apns` and `gcm`,
+  representing the argument for
+  [Apple Push Notification Service][apns]
+  and [Google Cloud Messaging][gcm]
+  respectively.
+
+- **topic** (string)
+
+  [Optional] The device topic, refer to application bundle identifier on iOS and application package name on Android
+
+Example:
 
 ```python
 user_ids = ["abcd-efgh", "efgh-abcd", "aceg-bdfh"]
 
 response = push_users(container, user_ids, notification)
 ```
+
+### Push to one device
+
+```python
+push_device(container, device_id, notification, topic=None)
+```
+
+- **container** (`SkygearContainer`)
+
+  An instance of the `SkygearContainer`, with the API key configured.
+
+- **device_id** (String)
+
+  The device ID which will receive the push notification. The prefix
+  `device/` is not necessary for the device ID.
+
+- **notification** (dictionary)
+
+  It should be a Python dictionary with two keys, `apns` and `gcm`,
+  representing the argument for
+  [Apple Push Notification Service][apns]
+  and [Google Cloud Messaging][gcm]
+  respectively.
+
+- **topic** (string)
+
+  [Optional] The device topic, refer to application bundle identifier on iOS and application package name on Android
+
+### Push to devices
+
+```python
+push_device(container, device_id, notification, topic=None)
+```
+
+- **container** (`SkygearContainer`)
+
+  An instance of the `SkygearContainer`, with the API key configured.
+
+- **device_ids** (List)
+
+  A list of device ID which will receive the push notification. The prefix
+  `device/` is not necessary for the device ID.
+
+- **notification** (dictionary)
+
+  It should be a Python dictionary with two keys, `apns` and `gcm`,
+  representing the argument for
+  [Apple Push Notification Service][apns]
+  and [Google Cloud Messaging][gcm]
+  respectively.
+
+- **topic** (string)
+
+  [Optional] The device topic, refer to application bundle identifier on iOS and application package name on Android
 
 ### Return Value
 

--- a/cloud-function/calling-skygear-api/python.md
+++ b/cloud-function/calling-skygear-api/python.md
@@ -323,7 +323,7 @@ push_device(container, device_id, notification, topic=None)
 ### Push to devices
 
 ```python
-push_device(container, device_id, notification, topic=None)
+push_devices(container, device_ids, notification, topic=None)
 ```
 
 - **container** (`SkygearContainer`)

--- a/cloud-function/calling-skygear-api/python.md
+++ b/cloud-function/calling-skygear-api/python.md
@@ -237,16 +237,16 @@ response = push_user(container, user_id, notification)
 push_user(container, user_id, notification, topic=None)
 ```
 
-- **container** (`SkygearContainer`)
+- **`container`** (`SkygearContainer`)
 
   An instance of the `SkygearContainer`, with the API key configured.
 
-- **user_id** (String)
+- **`user_id`** (String)
 
   The Skygear user ID who will receive the push notification. The prefix
   `user/` is not necessary for the user ID.
 
-- **notification** (dictionary)
+- **`notification`** (dictionary)
 
   It should be a Python dictionary with two keys, `apns` and `gcm`,
   representing the argument for
@@ -254,7 +254,7 @@ push_user(container, user_id, notification, topic=None)
   and [Google Cloud Messaging][gcm]
   respectively.
 
-- **topic** (string)
+- **`topic`** (string)
 
   [Optional] The device topic, refer to application bundle identifier on iOS and application package name on Android
 
@@ -264,16 +264,16 @@ push_user(container, user_id, notification, topic=None)
 push_users(container, user_ids, notification, topic=None)
 ```
 
-- **container** (`SkygearContainer`)
+- **`container`** (`SkygearContainer`)
 
   An instance of the `SkygearContainer`, with the API key configured.
 
-- **user_ids** (List)
+- **`user_ids`** (List)
 
   A list of Skygear user ID who will receive the push notification. The prefix
   `user/` is not necessary for the user ID.
 
-- **notification** (dictionary)
+- **`notification`** (dictionary)
 
   It should be a Python dictionary with two keys, `apns` and `gcm`,
   representing the argument for
@@ -281,7 +281,7 @@ push_users(container, user_ids, notification, topic=None)
   and [Google Cloud Messaging][gcm]
   respectively.
 
-- **topic** (string)
+- **`topic`** (string)
 
   [Optional] The device topic, refer to application bundle identifier on iOS and application package name on Android
 
@@ -299,16 +299,16 @@ response = push_users(container, user_ids, notification)
 push_device(container, device_id, notification, topic=None)
 ```
 
-- **container** (`SkygearContainer`)
+- **`container`** (`SkygearContainer`)
 
   An instance of the `SkygearContainer`, with the API key configured.
 
-- **device_id** (String)
+- **`device_id`** (String)
 
   The device ID which will receive the push notification. The prefix
   `device/` is not necessary for the device ID.
 
-- **notification** (dictionary)
+- **`notification`** (dictionary)
 
   It should be a Python dictionary with two keys, `apns` and `gcm`,
   representing the argument for
@@ -316,7 +316,7 @@ push_device(container, device_id, notification, topic=None)
   and [Google Cloud Messaging][gcm]
   respectively.
 
-- **topic** (string)
+- **`topic`** (string)
 
   [Optional] The device topic, refer to application bundle identifier on iOS and application package name on Android
 
@@ -330,12 +330,12 @@ push_device(container, device_id, notification, topic=None)
 
   An instance of the `SkygearContainer`, with the API key configured.
 
-- **device_ids** (List)
+- **`device_ids`** (List)
 
   A list of device ID which will receive the push notification. The prefix
   `device/` is not necessary for the device ID.
 
-- **notification** (dictionary)
+- **`notification`** (dictionary)
 
   It should be a Python dictionary with two keys, `apns` and `gcm`,
   representing the argument for
@@ -343,7 +343,7 @@ push_device(container, device_id, notification, topic=None)
   and [Google Cloud Messaging][gcm]
   respectively.
 
-- **topic** (string)
+- **`topic`** (string)
 
   [Optional] The device topic, refer to application bundle identifier on iOS and application package name on Android
 


### PR DESCRIPTION
Addressing the following issues:

In Python cloud functions doc (APIs in cloud functions):
* Missing the attributes of 'topic' (JS has it)
* Missing how to send notification to devices (JS has it)