### PR TITLE
Update js cloud reset password sample code

### DIFF
--- a/cloud-function/authenticating-users/js.md
+++ b/cloud-function/authenticating-users/js.md
@@ -23,4 +23,28 @@ skygearCloud.op('foo', function (param, options) {
 
 ## Reset Password
 
-Not implemented in JS.
+From v1.5.0 onwards, you can reset password for you users using `skygear.auth.adminResetPassword(user, newPassword)`. To call this function, you must use the master key of your Skygear app.
+
+Suppose we are writing a lambda function to be called by your admins at the client-side to reset password for a user.
+
+```Javascript
+const skygearCloud = require("skygear/cloud");
+
+const container = skygearCloud.getContainer();
+container.apiKey = skygearCloud.settings.masterKey;
+container.endPoint = skygearCloud.settings.skygearEndpoint + '/';
+
+skygearCloud.op('resetPasswordByAdmin', function(params){
+  // assume the user id and the new password are supplied by the client-side
+  let userId = params.args.userId
+  let newPassword = params.args.newPassword
+  /*
+   we suggest you checking whether this lambda call is made by an admin 
+   before calling adminResetPassword
+   */
+  container.auth.adminResetPassword(userId, newPassword)
+    .then((user) => console.log(user))
+    .catch((err) => console.log(err))
+})
+```
+Here we have configured a Skygear cloud container with the endpoint and the master key of our app. Normally you need to [supply a user_id to the container](https://docs.skygear.io/guides/cloud-function/calling-skygear-api/js/#skygear-container) so that you can make Skygear API calls on behalf of that user. However in the case of resetting password, we do not need to do so because when `adminResetPassword` is called with the master key, Skygear will reset the password of the user on behalf of himself.

--- a/cloud-function/authenticating-users/js.md
+++ b/cloud-function/authenticating-users/js.md
@@ -23,7 +23,7 @@ skygearCloud.op('foo', function (param, options) {
 
 ## Reset Password
 
-From v1.5.0 onwards, you can reset password for you users using `skygear.auth.adminResetPassword(user, newPassword)`. To call this function, you must use the master key of your Skygear app.
+From v1.5 onward, you can reset password for you users using `skygear.auth.adminResetPassword(user, newPassword)`. To call this function, you must use the master key of your Skygear app.
 
 Suppose we are writing a lambda function to be called by your admins at the client-side to reset password for a user.
 

--- a/cloud-function/lambda/js.md
+++ b/cloud-function/lambda/js.md
@@ -23,7 +23,7 @@ A lambda function can be created using the `@skygear.op` decorator.
 The method is:
 
 ```javascript
-op(name: String, func: function(param: Object, options: *), authRequired: Boolean, userRequired: Boolean)
+op(name: string, func: (param: object, options: any), options: { userRequired?: boolean, keyRequired?: boolean})
 ```
 
 - **`name`** (String)

--- a/cloud-function/lambda/js.md
+++ b/cloud-function/lambda/js.md
@@ -23,7 +23,7 @@ A lambda function can be created using the `@skygear.op` decorator.
 The method is:
 
 ```javascript
-op(name: string, func: (param: object, options: any), options: { userRequired?: boolean, keyRequired?: boolean})
+op(name: String, func: function(param: Object, options: *), options: {userRequired: boolean, keyRequired: boolean})
 ```
 
 - **`name`** (String)


### PR DESCRIPTION
from v1.5.0 onwards, Skygear JS SDK supports `adminResetPassword` method which can only be called with master key. 

Therefore adding this new API to the doc in the cloud functions section.